### PR TITLE
Fix owl icon resource references

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:color="@android:color/white" />
-    <foreground android:drawable="@drawable/ic_launcher_owl" />
+    <foreground android:drawable="@mipmap/ic_launcher_owl" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:color="@android:color/white" />
-    <foreground android:drawable="@drawable/ic_launcher_owl" />
+    <foreground android:drawable="@mipmap/ic_launcher_owl" />
 </adaptive-icon>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,7 +14,7 @@
         <item name="windowSplashScreenBackground">@color/white</item>
 
         <!-- Imagen central (PNG válido o VectorDrawable) -->
-        <item name="windowSplashScreenBrandingImage">@drawable/ic_launcher_owl</item>
+        <item name="windowSplashScreenBrandingImage">@mipmap/ic_launcher_owl</item>
 
         <!-- Tema que toma la app una vez finalizado el splash -->
         <item name="postSplashScreenTheme">@style/Theme.QPA</item>


### PR DESCRIPTION
## Summary
- use mipmap source for launcher drawables
- update splash theme to use mipmap icon

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a45a561f88330aaf26210b3df0fba