### PR TITLE
Fix auth null and reactive location

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,14 +15,16 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
         release {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 
@@ -51,33 +53,40 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.13.1")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
-    implementation("androidx.activity:activity-compose:1.9.0")
-    implementation("androidx.compose.ui:ui:1.6.7")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.6.7")
+    // Core y Jetpack
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.activity:activity-compose:1.7.2")
 
-    // ✅ AGREGADO: Material3 y SplashScreen
+    // Compose
+    implementation("androidx.compose.ui:ui:1.5.1")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.5.1")
     implementation("androidx.compose.material3:material3:1.2.1")
-    implementation("androidx.core:core-splashscreen:1.0.1")
+    implementation("androidx.navigation:navigation-compose:2.7.3")
 
-    implementation("androidx.navigation:navigation-compose:2.7.7")
-    implementation("io.coil-kt:coil-compose:2.6.0")
+    // IMPORTANTE: Añadir Material Components para Android (no solo Compose)
+    implementation("com.google.android.material:material:1.11.0")
 
-    implementation(platform("com.google.firebase:firebase-bom:33.15.0"))
+    // Firebase
+    implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-storage-ktx")
 
-    implementation("com.google.android.gms:play-services-maps:18.2.0")
-    implementation("com.google.android.gms:play-services-location:21.2.0")
-    implementation("com.google.maps.android:maps-compose:2.11.4")
-    implementation("com.google.maps.android:maps-utils-ktx:3.4.0")
+    // Google Maps y ubicación
+    implementation("com.google.maps.android:maps-compose:4.2.0")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
 
+    // Carga de imágenes
+    implementation("io.coil-kt:coil-compose:2.4.0")
+    implementation("androidx.compose.material:material-icons-extended:1.5.4")
+
+
+    // Test
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.6.7")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.6.7")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.6.7")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.5.1")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.5.1")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:1.5.1")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,23 +3,33 @@
     package="com.tramis.qpa">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
+
+
 
     <application
-        android:theme="@style/Theme.QPA"
+        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round">
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.QPA">
 
-        <activity
-            android:name=".MainActivity"
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyAieXEcrI68hemWqD7_8KlWSqjtj6XPfno" />
+
+        <activity android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.QPA.Splash">
+            android:theme="@style/Theme.QPA">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
     </application>
 
-
 </manifest>
+

--- a/app/src/main/java/com/tramis/qpa/MainActivity.kt
+++ b/app/src/main/java/com/tramis/qpa/MainActivity.kt
@@ -7,8 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AccountCircle
-import androidx.compose.material.icons.rounded.AddCircleOutline
-import androidx.compose.material.icons.rounded.Forum
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Place
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -34,6 +33,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.core.view.WindowCompat
 import com.google.firebase.auth.FirebaseAuth
 import com.tramis.qpa.screens.EditarSalaScreen
+import androidx.compose.material.icons.rounded.Forum
 
 
 class MainActivity : ComponentActivity() {
@@ -69,7 +69,7 @@ fun AppScaffold(navController: NavHostController) {
 
                 val items = listOf(
                     "home" to Icons.Rounded.Place,
-                    "crear" to Icons.Rounded.AddCircleOutline,
+                    "crear" to Icons.Rounded.Add,
                     "chatList" to Icons.Rounded.Forum,
                     "perfil" to Icons.Rounded.AccountCircle
                 )

--- a/app/src/main/java/com/tramis/qpa/screens/CrearNuevaSalaScreen.kt
+++ b/app/src/main/java/com/tramis/qpa/screens/CrearNuevaSalaScreen.kt
@@ -11,8 +11,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.google.firebase.auth.FirebaseUser
+import com.google.android.gms.maps.model.LatLng
 import com.tramis.qpa.utils.crearSala
-import com.tramis.qpa.utils.getCurrentLocation
+import com.tramis.qpa.utils.fetchCurrentLocation
 
 @Composable
 fun CrearNuevaSalaScreen(
@@ -27,7 +28,10 @@ fun CrearNuevaSalaScreen(
     var soloVisibles by remember { mutableStateOf(true) }
     var totem by remember { mutableStateOf("📍") }
 
-    val ubicacionActual = getCurrentLocation()
+    var ubicacionActual by remember { mutableStateOf<LatLng?>(null) }
+    LaunchedEffect(Unit) {
+        ubicacionActual = fetchCurrentLocation(context)
+    }
 
     Column(modifier = Modifier
         .fillMaxSize()
@@ -93,7 +97,8 @@ fun CrearNuevaSalaScreen(
                     Toast.makeText(context, "Ubicación o usuario no disponible", Toast.LENGTH_SHORT).show()
                 }
             },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            enabled = ubicacionActual != null && user != null
         ) {
             Text("Crear sala")
         }

--- a/app/src/main/java/com/tramis/qpa/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/tramis/qpa/screens/ProfileScreen.kt
@@ -33,7 +33,16 @@ import java.io.ByteArrayOutputStream
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileScreen(navController: NavController) {
-    val user = FirebaseAuth.getInstance().currentUser ?: return
+    val user = FirebaseAuth.getInstance().currentUser
+    if (user == null) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("No has iniciado sesión")
+        }
+        return
+    }
     val context = LocalContext.current
     val db = FirebaseFirestore.getInstance()
     val storage = FirebaseStorage.getInstance()

--- a/app/src/main/java/com/tramis/qpa/utils/FirebaseUtils.kt
+++ b/app/src/main/java/com/tramis/qpa/utils/FirebaseUtils.kt
@@ -52,6 +52,18 @@ fun getCurrentLocation(): LatLng? {
     return location
 }
 
+@SuppressLint("MissingPermission")
+suspend fun fetchCurrentLocation(context: Context): LatLng? {
+    val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
+    val loc = fusedLocationClient
+        .getCurrentLocation(
+            com.google.android.gms.location.Priority.PRIORITY_HIGH_ACCURACY,
+            null
+        )
+        .await()
+    return loc?.let { LatLng(it.latitude, it.longitude) }
+}
+
 @Composable
 fun useSalasListener(): List<Pair<String, Map<String, Any>>> {
     val salas = remember { mutableStateListOf<Pair<String, Map<String, Any>>>() }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Colores que estás usando en tu themes.xml -->
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>
+    <color name="white">#FFFFFFFF</color>
+    <color name="black">#FF000000</color>
+
+    <!-- Colores adicionales que podrías necesitar -->
     <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,23 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
-
-    <!-- Tema general de la app -->
-    <style name="Theme.QPA" parent="Theme.Material3.DayNight.NoActionBar">
+<resources>
+    <!-- Usar Theme.MaterialComponents que es más estable -->
+    <style name="Theme.QPA" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
-        <item name="android:statusBarColor" tools:targetApi="l">@color/purple_200</item>
+        <item name="colorSecondary">@color/purple_200</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <item name="android:statusBarColor">@color/purple_500</item>
     </style>
-
-    <!-- Tema exclusivo para el SplashScreen -->
-    <style name="Theme.QPA.Splash" parent="Theme.SplashScreen">
-        <!-- Fondo de pantalla inicial -->
-        <item name="windowSplashScreenBackground">@color/white</item>
-
-        <!-- Imagen central (PNG válido o VectorDrawable) -->
-        <item name="windowSplashScreenBrandingImage">@mipmap/ic_launcher_owl</item>
-
-        <!-- Tema que toma la app una vez finalizado el splash -->
-        <item name="postSplashScreenTheme">@style/Theme.QPA</item>
-    </style>
-
 </resources>


### PR DESCRIPTION
## Summary
- show a message when the profile screen has no authenticated user
- expose a suspend variant of `getCurrentLocation`
- use `remember` and `LaunchedEffect` to obtain location when creating a room
- merge latest main changes

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4dd578848330ac391e04b6ed5b1a